### PR TITLE
Release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,83 @@
 # CHANGELOG
 
+## 2.1.0
+
+### Non-backwards compatible changes
+
+- Custom `RequestMatchersGroup` must implement the order check and assertions on the same method.
+ 
+ ```java
+ void doAssert(@NonNull final RecordedRequest request, @NonNull final int currentOrder)
+ ```
+
+### Features
+
+- New enhanced exception message on assertion error. Example:
+
+```
+Unexpected exception during assertion. No matcher found for request: 
+
+> PATCH /head HTTP/1.1
+> Content-Type: application/json; charset=utf-8
+> Content-Length: 21
+> Host: localhost:52271
+> Connection: Keep-Alive
+> Accept-Encoding: gzip
+> User-Agent: okhttp/3.4.1
+
+{"property": "value"}
+
+Tried the following matchers:
+
+1. Request matchers group:
+ - method: is <DELETE>
+
+ Failed because METHOD did NOT match.
+ Expected: is <DELETE>
+      but: was <PATCH>
+
+2. Request matchers group:
+ - method: is <PATCH>
+ - request order: is <2>
+
+ Failed because REQUEST ORDER did NOT match.
+ Expected: is <2>
+      but: was <1>
+
+3. Request matchers group:
+ - method: is <PUT>
+
+ Failed because METHOD did NOT match.
+ Expected: is <PUT>
+      but: was <PATCH>
+
+4. Request matchers group:
+ - method: is <GET>
+
+ Failed because METHOD did NOT match.
+ Expected: is <GET>
+      but: was <PATCH>
+
+5. Request matchers group:
+ - method: is <POST>
+
+ Failed because METHOD did NOT match.
+ Expected: is <POST>
+      but: was <PATCH>
+
+6. Request matchers group:
+ - method: is <PATCH>
+ - query parameters: is map containing [is "key"->an instance of java.lang.String]
+
+ Failed because QUERY PARAMETERS did NOT match.
+ Expected: is map containing [is "key"->an instance of java.lang.String]
+      but: map was []
+```
+
+### Bugfixes
+
+- Multiple body assertions do not consume the response body. Thanks to @cleemansen. 
+
 ## 2.0.0
 
 - Major refactoring non-backwards compatible. Sticking to this API from now on.

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.parallel=true
 # ----------- PROJECT CONFIG --------------
 
 # VERSION
-VERSION_NAME=2.0.1-SNAPSHOT
+VERSION_NAME=2.1.0
 VERSION_CODE=3
 
 # PROJECT NAMESPACE

--- a/requestmatcher/src/main/java/br/com/concretesolutions/requestmatcher/RequestMatchersGroup.java
+++ b/requestmatcher/src/main/java/br/com/concretesolutions/requestmatcher/RequestMatchersGroup.java
@@ -41,7 +41,7 @@ public class RequestMatchersGroup {
     /**
      * Main assert method called in the {@link okhttp3.mockwebserver.MockWebServer} dispatching.
      */
-    public void doAssert(@NonNull final RecordedRequest request, @NonNull final int currentOrder) {
+    public void doAssert(@NonNull final RecordedRequest request, final int currentOrder) {
 
         if (methodMatcher != null) {
             assertThat(METHOD_MSG, HttpMethod.forRequest(request), methodMatcher);

--- a/requestmatcher/src/test/java/br/com/concretesolutions/requestmatcher/test/CustomRequestMatcherTest.java
+++ b/requestmatcher/src/test/java/br/com/concretesolutions/requestmatcher/test/CustomRequestMatcherTest.java
@@ -1,5 +1,7 @@
 package br.com.concretesolutions.requestmatcher.test;
 
+import android.support.annotation.NonNull;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -57,7 +59,7 @@ public class CustomRequestMatcherTest {
         }
 
         @Override
-        public void doAssert(RecordedRequest request, int currentOrder) {
+        public void doAssert(@NonNull RecordedRequest request, int currentOrder) {
             super.doAssert(request, currentOrder);
 
             if (shouldThrow) {


### PR DESCRIPTION
This release breaks the Custom Matcher api (assertOrder and doAssert are merged) therefore the minor version bump.

@cs-rafael-toledo 